### PR TITLE
Add postgres to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ RUN adduser -D microblog
 WORKDIR /home/microblog
 
 COPY requirements.txt requirements.txt
+
+RUN apk update \
+    && apk add libpq postgresql-dev \
+    && apk add build-base
+
 RUN python -m venv venv
 RUN venv/bin/pip install -r requirements.txt
 RUN venv/bin/pip install gunicorn pymysql


### PR DESCRIPTION
:wave:

Hi Miguel! Thank you for writing this great tutorial on Flask. I come back to it every so often to keep my python and flask skills up to date.

I noticed in the Dockerfile that postgres doesn't install when you run the build, generating the following error:

```
Collecting psycopg2==2.7.3.1 (from -r requirements.txt (line 39))
  Downloading https://files.pythonhosted.org/packages/6b/fb/15c687eda2f925f0ff59373063fdb408471b4284714a7761daaa65c01f15/psycopg2-2.7.3.1.tar.gz (425kB)
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    Error: pg_config executable not found.

    Please add the directory containing pg_config to the PATH
    or specify the full executable path with the option:

        python setup.py build_ext --pg-config /path/to/pg_config build ...

    or with the pg_config option in 'setup.cfg'.
```

I was able to resolve this by adding the necessary postgres dependencies to the Dockerfile as noted in the PR.

Please let me know if you have any questions, or if this Dockerfile is intended by design. Thanks! 😺 