### PR TITLE
Test of u2 for empty followers table

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -43,7 +43,7 @@ class UserModelCase(unittest.TestCase):
         db.session.add(u2)
         db.session.commit()
         self.assertEqual(u1.followed.all(), [])
-        self.assertEqual(u1.followers.all(), [])
+        self.assertEqual(u2.followers.all(), [])
 
         u1.follow(u2)
         db.session.commit()


### PR DESCRIPTION
Hello Miguel
I found that `u1` is tested twice for empty followers, and one of the tests should be changed to `u2`.
Assuming that the error is related to a copy/paste operation and persists from tag V0.8 until latest revision.

Thanks for a really nice tutorial.
Jesper