### PR TITLE
copy current ssh pub key to vagrant vm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,10 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/me.pub"
+  config.vm.provision "shell", inline: <<-SHELL
+    cat /home/vagrant/.ssh/me.pub >> /home/vagrant/.ssh/authorized_keys
+  SHELL
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "1024"
   end


### PR DESCRIPTION
See: https://stackoverflow.com/a/30075596/3343753

This reduces the tutorial chapter 17 section Password-less Logins to 0.

An ssh key pair must have previously been created, ie:

```
ssh-keygen
```